### PR TITLE
Fix clang 'address of array is always true' warning

### DIFF
--- a/pdl/Flux/Flux.xs
+++ b/pdl/Flux/Flux.xs
@@ -885,11 +885,11 @@ CODE:
  ptr = (void *)(FLUX->SvFluxPtr(sv,"_rbound", "Flux",0,1));
  field = fieldptr(ptr,typeno, fieldno);
 
- for(i=0;FLUX->F_B_NAMES[i].name && 
+ for(i=0;FLUX->F_B_NAMES[i].name[0] &&
 	( (void *)(FLUX->F_B_NAMES[i].func) != *field);
 	i++)
 	;
- if(FLUX->F_B_NAMES[i].name) {
+ if(FLUX->F_B_NAMES[i].name[0]) {
      sv = newSVpv(FLUX->F_B_NAMES[i].name,
 	 strlen(  FLUX->F_B_NAMES[i].name));
  } else {
@@ -925,12 +925,12 @@ CODE:
 	*field = 0;
  } else {
 	 for(j=0;
-	     FLUX->F_B_NAMES[j].name &&
+	     FLUX->F_B_NAMES[j].name[0] &&
 	     strcmp(FLUX->F_B_NAMES[j].name, what);
 	     j++)
 	printf("Trying 0x%lx (%s); value is %lx\n",(unsigned long)(FLUX->F_B_NAMES[j].func),FLUX->F_B_NAMES[j].name,(unsigned long)(*field));
 	       ;
-	 if(!(FLUX->F_B_NAMES[j].name)) {
+	 if(!(FLUX->F_B_NAMES[j].name[0])) {
 		char buf[10240];
 		sprintf(buf, "Unknown fluxon end condition '%s' (must be one of: %s", what, FLUX->F_B_NAMES[0].name);
 		for(j=1;FLUX->F_B_NAMES[j].func;j++) {

--- a/pdl/Flux/Vertex/Vertex.xs
+++ b/pdl/Flux/Vertex/Vertex.xs
@@ -74,9 +74,9 @@ CODE:
 	sprintf(str,"vertex %5ld (fl %5ld): xyz=%7.3g,%7.3g,%7.3g, |B|=%7.3g, n=%5ld,p=%5ld, out/in:%2d/%2d\n",
 	v->label,
 	v->line->label,
-	v->x ? v->x[0]:-1e64,
-	v->x ? v->x[1]:-1e64,
-	v->x ? v->x[2]:-1e64,
+	v->x[0],
+	v->x[1],
+	v->x[2],
 	v->b_mag,
 	v->next ? v->next->label : 0,
 	v->prev ? v->prev->label : 0, 
@@ -84,7 +84,7 @@ CODE:
         v->nearby.n
         );
   } else {
-	sprintf(str,"vertex %5ld (IMAGE; xyz may be invalid): xyz=%7.3g,%7.3g,%7.3g\n",v->label, v->x?v->x[0]:-1e64, v->x?v->x[1]:-1e64, v->x?v->x[2]:-1e64);
+	sprintf(str,"vertex %5ld (IMAGE; xyz may be invalid): xyz=%7.3g,%7.3g,%7.3g\n",v->label, v->x[0], v->x[1], v->x[2]);
   }
 
   RETVAL = str;


### PR DESCRIPTION
Several places were using a C array variable in a logical statement.
Apparently that just uses the address of the variable, which is
always non-zero, and thus true.  I either checked for the truthiness
of the 0th element of the character array, or just removed the
comparison for a numerical array.